### PR TITLE
Trigger and trigger-set event fixes.

### DIFF
--- a/index.js
+++ b/index.js
@@ -159,11 +159,11 @@ Ambient.prototype._fetchTriggerValues = function() {
       var lightTriggerValue = self._normalizeValue(data.readUInt16BE(0));
       var soundTriggerValue = self._normalizeValue(data.readUInt16BE(2));
 
-      if (lightTriggerValue)
+      if (lightTriggerValue && self.lightTriggerLevel)
       {
         self.emit('light-trigger', lightTriggerValue);
       }
-      if (soundTriggerValue)
+      if (soundTriggerValue && self.soundTriggerLevel)
       {
         self.emit('sound-trigger', soundTriggerValue);
       }


### PR DESCRIPTION
In this PR:
- changes the order of resetting IRQ to come after trigger event has been emitted. 
- command -> triggerCmd - bug that prevented light-trigger-set from ever being emitted
- now stores trigger levels on tessel, not just ambient module

Follow up - might be desirable to expose the set trigger levels through the API, though not necessary since they can be accessed as ambient.soundTriggerLevel etc.
