### PR TITLE
Remove redundant lines in ambient.js example

### DIFF
--- a/examples/ambient.js
+++ b/examples/ambient.js
@@ -11,10 +11,6 @@ trigger is met.
 var tessel = require('tessel');
 var ambient = require('../').use(tessel.port['A']); // Replace '../' with 'ambient-attx4' in your own code
 
-var ambientlib = require('../');// Replace '../' with 'ambient-attx4' in your own code
-
-var ambient = ambientlib.use(tessel.port['A']); 
-
 ambient.on('ready', function () {
  // Get a stream of light data
   ambient.on('light', function(data) {


### PR DESCRIPTION
The line above these two does the same thing and in a more succinct way. Removing them for clarity and to be consistent with other module examples.
