### PR TITLE
Add space.

### DIFF
--- a/examples/ambient.js
+++ b/examples/ambient.js
@@ -8,7 +8,7 @@ specified light or sound level trigger is met.
 *********************************************/
 
 var tessel = require('tessel');
-var ambientlib = require('../');// Replace '../' with 'ambient-attx4' in your own code
+var ambientlib = require('../'); // Replace '../' with 'ambient-attx4' in your own code
 
 var ambient = ambientlib.use(tessel.port['A']);
 


### PR DESCRIPTION
On the start.tessel.io page (or more specifically, this page: http://start.tessel.io/modules/ambient) you can still see the text `// Replace '../' with 'ambient-attx4' in your own code`, even though the code for the start.tessel.io site tries to strip this away. The reason is that this module is lacking a space in the comment.

This PR fixes that, and I have tested it against the start.tessel.io codebase and verified the page in question will render as expected.
